### PR TITLE
2019-11-13 GUARD-301 Variations-Not-Sync-By-Full-Inventory

### DIFF
--- a/src/EbayAccess/Models/ReviseFixedPriceItemRequest/ReviseFixedPriceItemRequest.cs
+++ b/src/EbayAccess/Models/ReviseFixedPriceItemRequest/ReviseFixedPriceItemRequest.cs
@@ -51,6 +51,25 @@ namespace EbayAccess.Models.ReviseFixedPriceItemRequest
 				result.Quantity = source.First().Quantity;
 				result.StartPrice = source.First().StartPrice;
 				result.ConditionID = source.First().ConditionID;
+				result.Variations.AddRange( source.First().Variations );
+			}
+
+			return result;
+		}
+
+		public static ReviseFixedPriceItemRequest ToReviseFixedPriceItemRequestWithVariations( this IGrouping< long, UpdateInventoryRequest > source )
+		{
+			var result = new ReviseFixedPriceItemRequest() { ItemId = source.Key };
+
+			if ( source.Count() > 1 )
+			{
+				result.Variations.AddRange( source.Select( i => new ReviseFixedPriceItemVariationRequest() { Quantity = i.Quantity, Sku = i.Sku } ) );
+			}
+			else
+			{
+				result.Sku = source.First().Sku;
+				result.Quantity = source.First().Quantity;
+				result.ConditionID = source.First().ConditionID;
 			}
 
 			return result;

--- a/src/EbayAccessTests.Integration/EbayServiceTest.cs
+++ b/src/EbayAccessTests.Integration/EbayServiceTest.cs
@@ -129,6 +129,32 @@ namespace EbayAccessTests.Integration
 		}
 
 		[ Test ]
+		public void UpdateInventoryAsyncEconom_UpdateMoreThanFourItemsWithoutVariationsAndNotAndRandomOrder()
+		{
+			//------------ Arrange
+			var ebayService = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
+			var rand = new Random();
+
+			//------------ Act
+			var requests = new List< UpdateInventoryRequest >
+			{
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithVariation1.ItemId, Sku = ExistingProducts.FixedPrice1WithVariation1.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithVariation2.ItemId, Sku = ExistingProducts.FixedPrice1WithVariation2.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithVariation3.ItemId, Sku = ExistingProducts.FixedPrice1WithVariation3.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithoutVariations.ItemId, Sku = ExistingProducts.FixedPrice1WithoutVariations.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithVariation4.ItemId, Sku = ExistingProducts.FixedPrice1WithVariation4.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice1WithVariation5.ItemId, Sku = ExistingProducts.FixedPrice1WithVariation5.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+				new UpdateInventoryRequest { ItemId = ExistingProducts.FixedPrice2WithoutVariations.ItemId, Sku = ExistingProducts.FixedPrice2WithoutVariations.Sku, Quantity = rand.Next( 1, 100), IsVariation = false },
+			};
+
+			var updateProductsAsyncTask1 = ebayService.UpdateInventoryAsync( requests, UpdateInventoryAlgorithm.Econom );
+			updateProductsAsyncTask1.Wait();
+
+			//------------ Assert
+			updateProductsAsyncTask1.Result.Count().Should().Be( 3 );
+		}
+
+		[ Test ]
 		[ TestCase( UpdateInventoryAlgorithm.Econom ) ]
 		[ TestCase( UpdateInventoryAlgorithm.Old ) ]
 		public void UpdateInventoryAsync_UpdateFixedPriceItemWithVariationsAndNonvariation_NoExceptionOccuredAndResponseNotEmpty( UpdateInventoryAlgorithm algorithm )

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.44.0" ) ]
+[ assembly : AssemblyVersion( "1.1.45.0" ) ]


### PR DESCRIPTION
Summary
I discovered that than SV simultaneously sends two and more requests and each of them has similar itemId included but various skus only one request will be executed on Ebay side.
To fix this I followed eBay documentation where specified that listings with variations should be updated only via ReviseFixedPriceItem API endpoint.

https://developer.ebay.com/devzone/xml/docs/reference/ebay/ReviseInventoryStatus.html
> To update the price and/or quantity of a variation within a multiple-variation listing, the ReviseFixedPriceItem call must be used instead, passing in this updated price or quantity information through the corresponding Variations.Variation node for that product variation.

