### PR TITLE
2020-09-16 GUARD-828 Truncate-Logs

### DIFF
--- a/src/EbayAccess/EbayService.cs
+++ b/src/EbayAccess/EbayService.cs
@@ -923,10 +923,10 @@ namespace EbayAccess
 				"{{MethodName:{0}, Mark:'{3}', RestInfo:{1}, MethodParameters:{2}{4}{5}{6}}}",
 				memberName,
 				restInfo,
-				methodParameters,
+				methodParameters.LimitBodyLogSize(),
 				mark,
-				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors,
-				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult,
+				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors.LimitResponseLogSize(),
+				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult.LimitResponseLogSize(),
 				string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", " + additionalInfo
 				);
 			return str;

--- a/src/EbayAccess/Misc/EbayLogger.cs
+++ b/src/EbayAccess/Misc/EbayLogger.cs
@@ -5,7 +5,7 @@ namespace EbayAccess.Misc
 	public static class EbayLogger
 	{
 		private const string EbayIntegrationMarker = "ebay";
-		public static int MaxLogLineSize = 0xA00000; //10mb
+		public static int MaxLogLineSize = 100000;
 
 		public static ILogger Log()
 		{

--- a/src/EbayAccess/Misc/EbayLogger.cs
+++ b/src/EbayAccess/Misc/EbayLogger.cs
@@ -4,6 +4,9 @@ namespace EbayAccess.Misc
 {
 	public static class EbayLogger
 	{
+		private const string EbayIntegrationMarker = "ebay";
+		public static int MaxLogLineSize = 0xA00000; //10mb
+
 		public static ILogger Log()
 		{
 			return NetcoLogger.GetLogger( "EbayLogger" );
@@ -11,36 +14,47 @@ namespace EbayAccess.Misc
 
 		public static void LogTraceStarted( string info )
 		{
-			Log().Trace( "[ebay] Start call:{0}.", info );
+			TraceLog( "Start call", info );
 		}
 
 		public static void LogTraceEnded( string info )
 		{
-			Log().Trace( "[ebay] End call:{0}.", info );
+			TraceLog( "End call", info );
 		}
-		public static void LogTrace(string info)
+		public static void LogTrace( string info )
 		{
-			Log().Trace("[ebay] Trace call:{0}.", info);
+			TraceLog( "Trace call", info );
 		}
 
 		public static void LogTraceInnerStarted( string info )
 		{
-			Log().Trace( "[ebay] Internal Start call:{0}.", info );
+			TraceLog( "Internal Start call", info );
 		}
 
 		public static void LogTraceInnerEnded( string info )
 		{
-			Log().Trace( "[ebay] Internal End call:{0}.", info );
+			TraceLog( "Internal End call", info );
 		}
 
 		public static void LogTraceInnerError( string info )
 		{
-			Log().Trace( "[ebay] Internal error:{0}.", info );
+			TraceLog( "Internal error", info );
 		}
 
-		public static void LogTraceInnerErrorSkipped(string info)
+		public static void LogTraceInnerErrorSkipped( string info )
 		{
-			Log().Trace("[ebay] Internal error (skipped):{0}.", info);
+			TraceLog( "Internal error (skipped)", info );
+		}
+
+		private static void TraceLog( string type, string info )
+		{
+			if ( info != null 
+				&& info.Length > MaxLogLineSize )
+			{
+				info = info.Substring( 0, MaxLogLineSize );
+			}
+
+			Log().Trace( "[{channel}] {type}:{info}", EbayIntegrationMarker, type, info );
 		}
 	}
 }

--- a/src/EbayAccess/Misc/Extensions.cs
+++ b/src/EbayAccess/Misc/Extensions.cs
@@ -18,7 +18,8 @@ namespace EbayAccess.Misc
 {
 	public static class Extensions
 	{
-		public static int MaxStringSize = 95000;
+		public static int MaxResponseLogSize = 95000;
+		public static int MaxBodyLogSize = 95000;
 
 		#region StringTo
 		public static Stream ToStream( this string source, Encoding encoding = null )
@@ -365,15 +366,25 @@ namespace EbayAccess.Misc
 			}
 		}
 
-		public static string LimitStringSize( this string source )
+		public static string LimitResponseLogSize( this string source )
 		{
-			if ( string.IsNullOrWhiteSpace( source ) )
-				return source;
+			return LimitLogSize( source, MaxResponseLogSize );
+		}
 
-			if ( source.Length > MaxStringSize )
-				source = source.Substring( 0, MaxStringSize );
+		public static string LimitBodyLogSize( this string source )
+		{
+			return LimitLogSize( source, MaxBodyLogSize );
+		}
 
-			return source;
+		private static string LimitLogSize( string logLine, int limit )
+		{
+			if ( string.IsNullOrWhiteSpace( logLine ) )
+				return logLine;
+
+			if ( logLine.Length > limit )
+				logLine = logLine.Substring( 0, limit );
+
+			return logLine;
 		}
 	}
 }

--- a/src/EbayAccess/Misc/Extensions.cs
+++ b/src/EbayAccess/Misc/Extensions.cs
@@ -18,6 +18,8 @@ namespace EbayAccess.Misc
 {
 	public static class Extensions
 	{
+		public static int MaxStringSize = 95000;
+
 		#region StringTo
 		public static Stream ToStream( this string source, Encoding encoding = null )
 		{
@@ -361,6 +363,17 @@ namespace EbayAccess.Misc
 			{
 				return PredefinedValues.EmptyJsonObject;
 			}
+		}
+
+		public static string LimitStringSize( this string source )
+		{
+			if ( string.IsNullOrWhiteSpace( source ) )
+				return source;
+
+			if ( source.Length > MaxStringSize )
+				source = source.Substring( 0, MaxStringSize );
+
+			return source;
 		}
 	}
 }

--- a/src/EbayAccess/Services/WebRequestServices.cs
+++ b/src/EbayAccess/Services/WebRequestServices.cs
@@ -175,10 +175,10 @@ namespace EbayAccess.Services
 			var str = string.Format(
 				"{{MethodName:{0}, Mark:'{2}', MethodParameters:{1}{3}{4}{5}}}",
 				memberName,
-				methodParameters.LimitStringSize(),
+				methodParameters.LimitBodyLogSize(),
 				mark,
-				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors.LimitStringSize(),
-				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult.LimitStringSize(),
+				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors.LimitResponseLogSize(),
+				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult.LimitResponseLogSize(),
 				string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", " + additionalInfo
 				);
 			return str;

--- a/src/EbayAccess/Services/WebRequestServices.cs
+++ b/src/EbayAccess/Services/WebRequestServices.cs
@@ -157,7 +157,7 @@ namespace EbayAccess.Services
 					await dataStream.CopyToAsync( memoryStream, 0x100, cts ).ConfigureAwait( false );
 					memoryStream.Position = 0;
 
-					EbayLogger.LogTraceInnerEnded( this.CreateMethodCallInfo( webRequest.RequestUri.ToString(), mark, memoryStream.ToStringSafe() ) );
+					EbayLogger.LogTraceInnerEnded( this.CreateMethodCallInfo( webRequest.RequestUri.ToString(), mark, methodResult: memoryStream.ToStringSafe() ) );
 
 					return memoryStream;
 				}
@@ -175,10 +175,10 @@ namespace EbayAccess.Services
 			var str = string.Format(
 				"{{MethodName:{0}, Mark:'{2}', MethodParameters:{1}{3}{4}{5}}}",
 				memberName,
-				methodParameters,
+				methodParameters.LimitStringSize(),
 				mark,
-				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors,
-				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult,
+				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors.LimitStringSize(),
+				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult.LimitStringSize(),
 				string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", " + additionalInfo
 				);
 			return str;

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -33,11 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CuttingEdge.Conditions, Version=1.2.0.11174, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>
+    </Reference>
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.2.2.0.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1312.1622\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Netco, Version=1.4.3.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Netco.1.4.3\lib\net45\Netco.dll</HintPath>
     </Reference>
     <Reference Include="NSubstitute">
       <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET45\NSubstitute.dll</HintPath>
@@ -59,6 +65,7 @@
     </Compile>
     <Compile Include="EbayServiceTest.cs" />
     <Compile Include="Misc\Extensions.cs" />
+    <Compile Include="Misc\LoggerTests.cs" />
     <Compile Include="Models\CredentialsAndConfig\EbayConfigTest.cs" />
     <Compile Include="Models\GetSellerListResponse\ItemExtendedTest.cs" />
     <Compile Include="Models\GetSellerListResponse\ProductTests.cs" />

--- a/src/EbayAccessTests/Misc/Extensions.cs
+++ b/src/EbayAccessTests/Misc/Extensions.cs
@@ -303,22 +303,33 @@ namespace EbayAccessTests.Misc
 		}
 
 		[ Test ]
-		public void GivenNullStr_WhenLimitStringSizeCalled_ThenSameStrIsReturned()
+		public void GivenNullResponse_WhenLimitResponseLogSizeCalled_ThenSameResponseIsReturned()
 		{
-			string testStr = null;
-			var limitedStr = testStr.LimitStringSize();
-			limitedStr.Should().BeNull();
+			string response = null;
+			var truncatedResponse = response.LimitResponseLogSize();
+			truncatedResponse.Should().BeNull();
 		}
 
 		[ Test ]
-		public void GivenStrWithSizeHigherThanLimit_WhenLimitStringSizeCalled_ThenLimitedStrIsReturned()
+		public void GivenResponseWithSizeHigherThanMaxLogSize_WhenLimitResponseLogSizeCalled_ThenTruncatedResponseLogIsReturned()
 		{
-			var testStr = "SkuVault";
-			EbayAccess.Misc.Extensions.MaxStringSize = 2;
+			var response = "SkuVault";
+			EbayAccess.Misc.Extensions.MaxResponseLogSize = 2;
 
-			var limitedStr = testStr.LimitStringSize();
+			var truncatedResponse = response.LimitResponseLogSize();
 
-			limitedStr.Length.Should().Be( EbayAccess.Misc.Extensions.MaxStringSize );
+			truncatedResponse.Length.Should().Be( EbayAccess.Misc.Extensions.MaxResponseLogSize );
+		}
+
+		[ Test ]
+		public void GivenBodyWithSizeHigherThanMaxLogSize_WhenLimitBodyLogSizeCalled_ThenTruncatedBodyLogIsReturned()
+		{
+			var body = "Some huge payload from SkuVault here!";
+			EbayAccess.Misc.Extensions.MaxBodyLogSize = 2;
+
+			var truncatedBody = body.LimitBodyLogSize();
+
+			truncatedBody.Length.Should().Be( EbayAccess.Misc.Extensions.MaxBodyLogSize );
 		}
 	}
 }

--- a/src/EbayAccessTests/Misc/Extensions.cs
+++ b/src/EbayAccessTests/Misc/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using EbayAccess.Misc;
 using EbayAccess.Models;
 using EbayAccess.Models.BaseResponse;
@@ -299,6 +300,25 @@ namespace EbayAccessTests.Misc
 			str1.Should().NotBeNullOrWhiteSpace();
 			str2.Should().NotBeNullOrWhiteSpace();
 			str3.Should().NotBeNullOrWhiteSpace();
+		}
+
+		[ Test ]
+		public void GivenNullStr_WhenLimitStringSizeCalled_ThenSameStrIsReturned()
+		{
+			string testStr = null;
+			var limitedStr = testStr.LimitStringSize();
+			limitedStr.Should().BeNull();
+		}
+
+		[ Test ]
+		public void GivenStrWithSizeHigherThanLimit_WhenLimitStringSizeCalled_ThenLimitedStrIsReturned()
+		{
+			var testStr = "SkuVault";
+			EbayAccess.Misc.Extensions.MaxStringSize = 2;
+
+			var limitedStr = testStr.LimitStringSize();
+
+			limitedStr.Length.Should().Be( EbayAccess.Misc.Extensions.MaxStringSize );
 		}
 	}
 }

--- a/src/EbayAccessTests/Misc/LoggerTests.cs
+++ b/src/EbayAccessTests/Misc/LoggerTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using EbayAccess.Misc;
+using Netco.Logging;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace EbayAccessTests.Misc
+{
+	[ TestFixture ]
+	public class LoggerTests
+	{
+		private ILogger _logger;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._logger = Substitute.For< ILogger >();
+			NetcoLogger.LoggerFactory = new LoggerFactoryStub( this._logger );
+		}
+
+		[ Test ]
+		public void GivenInfoStringWithNormalSize_WhenTraceInfoCalled_ThenSameInfoShouldBeWrittenToLog()
+		{
+			EbayLogger.MaxLogLineSize = 5;
+			var infoMessage = "hello";
+
+			EbayLogger.LogTrace( infoMessage );
+			this._logger.Received().Trace( "[{channel}] {type}:{info}", "ebay", "Trace call", infoMessage );
+		}
+
+		[ Test ]
+		public void GivenInfoStringWithAbnormalSize_WhenTraceInfoCalled_ThenTruncatedInfoShouldBeWrittenToLog()
+		{
+			EbayLogger.MaxLogLineSize = 5;
+			var infoMessage = "hello world!";
+
+			EbayLogger.LogTrace( infoMessage );
+			this._logger.Received().Trace( "[{channel}] {type}:{info}", "ebay", "Trace call", infoMessage.Substring( 0, EbayLogger.MaxLogLineSize ) );
+		}
+
+		[ Test ]
+		public void GivenNullInfoString_WhenTraceInfoCalled_ThenNullShouldBeWrittenToLog()
+		{
+			EbayLogger.MaxLogLineSize = 5;
+
+			EbayLogger.LogTrace( null );
+			this._logger.Received().Trace( "[{channel}] {type}:{info}", "ebay", "Trace call", null );
+		}
+	}
+
+	internal class LoggerFactoryStub : ILoggerFactory
+	{
+		public ILogger Logger { get; private set; }
+
+		public LoggerFactoryStub( ILogger logger )
+		{
+			this.Logger = logger;
+		}
+
+		public ILogger GetLogger( Type objectToLogType )
+		{
+			return this.Logger;
+		}
+
+		public ILogger GetLogger( string loggerName )
+		{
+			return this.Logger;
+		}
+	}
+}

--- a/src/EbayAccessTests/packages.config
+++ b/src/EbayAccessTests/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-	<package id="FluentAssertions" version="2.2.0.0" targetFramework="net45" />
-	<package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
-	<package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
-	<package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="2.2.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
+  <package id="Netco" version="1.4.3" targetFramework="net45" />
+  <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.2.3.0" ) ]
+[ assembly : AssemblyVersion( "1.2.4.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.2.2.0" ) ]
+[ assembly : AssemblyVersion( "1.2.3.0" ) ]


### PR DESCRIPTION
**Summary**

Some tenants use Auctiva ebay plugin (https://www.auctiva.com/products/pages/auctiva-scrolling-gallery.aspx) to add related products gallery to product description.
Example:
https://www.ebay.com/itm/2-LIGHT-UP-FLASHING-SNOWFLAKE-14IN-WAND-party-lightup-novelties-holiday-supplies/232450531773

The issue is logging all this data to Kibana. The library writes the whole API response from eBay to logs, it includes all products data. As a result our hour log file can have 30GB size in unpacked state.