### PR TITLE
GUARD-876 Orders Sync Error

### DIFF
--- a/src/EbayAccess/EbayService.cs
+++ b/src/EbayAccess/EbayService.cs
@@ -35,9 +35,9 @@ namespace EbayAccess
 
 		private IEbayServiceLowLevel EbayServiceLowLevel { get; set; }
 
-		public EbayService( EbayUserCredentials credentials, EbayConfig ebayConfig, IWebRequestServices webRequestServices )
+		public EbayService( EbayUserCredentials credentials, EbayConfig ebayConfig, IWebRequestServices webRequestServices, int requestTimeoutMs = EbayAccess.Services.EbayServiceLowLevel.MaxRequestTimeoutMs )
 		{
-			this.EbayServiceLowLevel = new EbayServiceLowLevel( credentials, ebayConfig, webRequestServices );
+			this.EbayServiceLowLevel = new EbayServiceLowLevel( credentials, ebayConfig, webRequestServices, requestTimeoutMs );
 		}
 
 		public EbayService( EbayUserCredentials credentials, EbayConfig ebayConfig ) : this( credentials, ebayConfig, new WebRequestServices() )

--- a/src/EbayAccess/IEbayService.cs
+++ b/src/EbayAccess/IEbayService.cs
@@ -14,7 +14,7 @@ namespace EbayAccess
 {
 	public interface IEbayService
 	{
-		Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo );
+		Task< IEnumerable< Order > > GetOrdersAsync( DateTime dateFrom, DateTime dateTo, CancellationToken token );
 
 		Task< IEnumerable< InventoryStatusResponse > > ReviseInventoriesStatusAsync( IEnumerable< InventoryStatusRequest > products );
 
@@ -36,13 +36,12 @@ namespace EbayAccess
 
 		string FetchUserToken( string sessionId );
 
-		Task< List< string > > GetOrdersIdsAsync( params string[] sourceOrdersIds );
+		Task< List< string > > GetOrdersIdsAsync( CancellationToken token, params string[] sourceOrdersIds );
 
-		Task< List< string > > GetSaleRecordsNumbersAsync( IEnumerable< string > saleRecordsIDs, GetSaleRecordsNumbersAlgorithm usealgorithm );
+		Task< List< string > > GetSaleRecordsNumbersAsync( IEnumerable< string > saleRecordsIDs, CancellationToken token, GetSaleRecordsNumbersAlgorithm usealgorithm );
 
 		Task< IEnumerable< UpdateInventoryResponse > > UpdateInventoryAsync( IEnumerable< UpdateInventoryRequest > products, UpdateInventoryAlgorithm usealgorithm = UpdateInventoryAlgorithm.Old, string mark = null );
 
 		Func< string > AdditionalLogInfo { get; set; }
-		Dictionary< string, int > DelayForMethod { get; }
 	}
 }

--- a/src/EbayAccess/Misc/ActionPolicies.cs
+++ b/src/EbayAccess/Misc/ActionPolicies.cs
@@ -33,8 +33,9 @@ namespace EbayAccess.Misc
 				await Task.Delay( TimeSpan.FromSeconds( 0.5 + i ) ).ConfigureAwait( false );
 			} );
 
+		public const int GetAsyncShortMaxRetries = 3;
 		private static readonly ActionPolicyAsync _ebayGetAsyncPolicyShort = ActionPolicyAsync.Handle< Exception >()
-			.RetryAsync( 3, async ( ex, i ) =>
+			.RetryAsync( GetAsyncShortMaxRetries, async ( ex, i ) =>
 			{
 				EbayLogger.Log().Trace( ex, "Retrying Ebay API get call for the {0} time", i );
 				await Task.Delay( TimeSpan.FromSeconds( 0.5 + i ) ).ConfigureAwait( false );

--- a/src/EbayAccess/Services/EbayServiceLowLevel.cs
+++ b/src/EbayAccess/Services/EbayServiceLowLevel.cs
@@ -24,7 +24,6 @@ using EbayAccess.Models.ReviseInventoryStatusResponse;
 using EbayAccess.Services.Parsers;
 using Netco.Extensions;
 using Item = EbayAccess.Models.GetSellerListResponse.Item;
-using Order = EbayAccess.Models.GetSellingManagerSoldListingsResponse.Order;
 
 namespace EbayAccess.Services
 {
@@ -40,10 +39,12 @@ namespace EbayAccess.Services
 		private readonly string _endPointBulkExhange;
 
 		public int MaxThreadsCount => 5;
+		private const int MaxRequestTimeoutMs = 30 * 60 * 1000;
+		private int RequestTimeoutMs;
 
 		public Func< string > AdditionalLogInfo { get; set; }
 
-		public EbayServiceLowLevel( EbayUserCredentials credentials, EbayConfig ebayConfig, IWebRequestServices webRequestServices )
+		public EbayServiceLowLevel( EbayUserCredentials credentials, EbayConfig ebayConfig, IWebRequestServices webRequestServices, int requestTimeoutMs = MaxRequestTimeoutMs )
 		{
 			Condition.Requires( credentials, "credentials" ).IsNotNull();
 			Condition.Requires( webRequestServices, "webRequestServices" ).IsNotNull();
@@ -56,6 +57,7 @@ namespace EbayAccess.Services
 			this._ebaySignInUrl = ebayConfig.SignInUrl;
 			this._itemsPerPage = 200;
 			this._ebayConfig = ebayConfig;
+			this.RequestTimeoutMs = requestTimeoutMs;
 		}
 
 		public EbayServiceLowLevel( EbayUserCredentials userCredentials, EbayConfig ebayConfig )
@@ -64,10 +66,10 @@ namespace EbayAccess.Services
 		}
 
 		#region EbayStandartRequest
-		private async Task< WebRequest > CreateEbayStandartPostRequestAsync( string url, Dictionary< string, string > headers, string body, string mark, CancellationToken cts )
+		private async Task< WebRequest > CreateEbayStandardPostRequestAsync( string url, Dictionary< string, string > headers, string body, string mark, CancellationToken cts )
 		{
 			if( cts.IsCancellationRequested )
-				return null;
+				throw new TaskCanceledException( $"Request was cancelled or timed out, Mark: {mark}" );
 
 			if( !headers.Exists( keyValuePair => keyValuePair.Key == EbayHeaders.XEbayApiCompatibilityLevel ) )
 				headers.Add( EbayHeaders.XEbayApiCompatibilityLevel, EbayHeadersValues.XEbayApiCompatibilityLevel );
@@ -84,29 +86,30 @@ namespace EbayAccess.Services
 			return await this._webRequestServices.CreateServicePostRequestAsync( url, body, headers, cts, mark ).ConfigureAwait( false );
 		}
 
-		public WebRequest CreateEbayStandartPostRequest( string url, Dictionary< string, string > headers, string body, string mark )
+		public WebRequest CreateEbayStandardPostRequest( string url, Dictionary< string, string > headers, string body, string mark )
 		{
-			var resultTask = this.CreateEbayStandartPostRequestAsync( url, headers, body, mark, CancellationToken.None );
+			var resultTask = this.CreateEbayStandardPostRequestAsync( url, headers, body, mark, CancellationToken.None );
 			resultTask.Wait();
 			return resultTask.Result;
 		}
 
-		public async Task< WebRequest > CreateEbayStandartPostRequestWithCertAsync( string url, Dictionary< string, string > headers, string body, string mark, CancellationToken cts )
+		public async Task< WebRequest > CreateEbayStandardPostRequestWithCertAsync( string url, Dictionary< string, string > headers, string body, string mark, CancellationToken cts )
 		{
 			if( !headers.Exists( keyValuePair => keyValuePair.Key == EbayHeaders.XEbayApiCertName ) )
 				headers.Add( EbayHeaders.XEbayApiCertName, this._ebayConfig.CertName );
 
-			return await this.CreateEbayStandartPostRequestAsync( url, headers, body, mark, cts ).ConfigureAwait( false );
+	var ebayStandartPostRequestAsync = await this.CreateEbayStandardPostRequestAsync( url, headers, body, mark, cts ).ConfigureAwait( false );
+			return ebayStandartPostRequestAsync;
 		}
 
-		public async Task< WebRequest > CreateEbayStandartPostRequestToBulkExchangeServerAsync( string url, Dictionary< string, string > headers, string body, string mark = "" )
+		public async Task< WebRequest > CreateEbayStandardPostRequestToBulkExchangeServerAsync( string url, Dictionary< string, string > headers, string body, string mark = "" )
 		{
 			return await this._webRequestServices.CreateServicePostRequestAsync( url, body, headers, CancellationToken.None, mark ).ConfigureAwait( false );
 		}
 
-		public WebRequest CreateEbayStandartPostRequestWithCert( string url, Dictionary< string, string > headers, string body, string mark )
+		public WebRequest CreateEbayStandardPostRequestWithCert( string url, Dictionary< string, string > headers, string body, string mark )
 		{
-			var requestTask = this.CreateEbayStandartPostRequestWithCertAsync( url, headers, body, mark, CancellationToken.None );
+			var requestTask = this.CreateEbayStandardPostRequestWithCertAsync( url, headers, body, mark, CancellationToken.None );
 			requestTask.Wait();
 			return requestTask.Result;
 		}
@@ -194,13 +197,13 @@ namespace EbayAccess.Services
 			).ConfigureAwait( false );
 		}
 
-		public async Task< GetSellingManagerSoldListingsResponse > GetSellngManagerOrderByRecordNumberAsync( string salerecordNumber, string mark, CancellationToken cts )
+		public async Task< GetSellingManagerSoldListingsResponse > GetSellingManagerOrderByRecordNumberAsync( string saleRecordNumber, string mark, CancellationToken cts )
 		{
 			return await this.GetEbaySingleRequestAsync(
 				headers : CreateEbayGetSellingManagerSoldListingsRequestHeadersWithApiCallName(),
-				body : this.CreateGetSellingManagerSoldListingsRequestBody( salerecordNumber ),
+				body : this.CreateGetSellingManagerSoldListingsRequestBody( saleRecordNumber ),
 				responseParser : x => new EbayGetSellingManagerSoldListingsResponseParser().Parse( x ),
-				cts : cts,
+				token : cts,
 				mark : mark,
 				useCert: true
 			).ConfigureAwait( false );
@@ -214,7 +217,7 @@ namespace EbayAccess.Services
 			var recordsPerPage = this._itemsPerPage;
 			const int pageNumber = 1;
 
-			var sellingManagerSoldListings = await this.GetSellngManagerSoldListingsByPeriodSinglePageAsync( ct, timeFrom, timeTo, recordsPerPage, pageNumber, mark ).ConfigureAwait( false );
+			var sellingManagerSoldListings = await this.GetSellingManagerSoldListingsByPeriodSinglePageAsync( ct, timeFrom, timeTo, recordsPerPage, pageNumber, mark ).ConfigureAwait( false );
 
 			if( sellingManagerSoldListings == null || sellingManagerSoldListings.Errors != null )
 				return sellingManagerSoldListings;
@@ -240,7 +243,7 @@ namespace EbayAccess.Services
 				pages.Add( i );
 			}
 
-			var sellingManagerSoldListingsTempList = await pages.ProcessInBatchAsync( this.MaxThreadsCount, async x => await this.GetSellngManagerSoldListingsByPeriodSinglePageAsync( ct, timeFrom, timeTo, recordsPerPage, x, mark ).ConfigureAwait( false ) ).ConfigureAwait( false );
+			var sellingManagerSoldListingsTempList = await pages.ProcessInBatchAsync( this.MaxThreadsCount, async x => await this.GetSellingManagerSoldListingsByPeriodSinglePageAsync( ct, timeFrom, timeTo, recordsPerPage, x, mark ).ConfigureAwait( false ) ).ConfigureAwait( false );
 
 			sellingManagerSoldListingsTempList.ForEach( x =>
 			{
@@ -259,13 +262,13 @@ namespace EbayAccess.Services
 			return sellingManagerSoldListings;
 		}
 
-		private async Task< GetSellingManagerSoldListingsResponse > GetSellngManagerSoldListingsByPeriodSinglePageAsync( CancellationToken ct, DateTime timeFrom, DateTime timeTo, int recordsPerPage, int pageNumber, string mark = "" )
+		private async Task< GetSellingManagerSoldListingsResponse > GetSellingManagerSoldListingsByPeriodSinglePageAsync( CancellationToken ct, DateTime timeFrom, DateTime timeTo, int recordsPerPage, int pageNumber, string mark = "" )
 		{
 			return await this.GetEbaySingleRequestAsync(
 				headers : CreateEbayGetSellingManagerSoldListingsRequestHeadersWithApiCallName(),
 				body : this.CreateGetSellingManagerSoldListingsRequestBody( timeFrom, timeTo, recordsPerPage, pageNumber ),
 				responseParser : x => new EbayGetSellingManagerSoldListingsResponseParser().Parse( x ),
-				cts : ct,
+				token : ct,
 				mark : mark,
 				useCert : true
 			).ConfigureAwait( false );
@@ -340,7 +343,7 @@ namespace EbayAccess.Services
 			return await this.GetEbayMultiPageRequestAsync(
 				headers : CreateGetSellerListRequestHeadersWithApiCallName(),
 				getRequestBodyByPageNumber : page => this.CreateGetSellerListCustomRequestBody( timeFrom, timeTo, getSellerListTimeRangeEnum, this._itemsPerPage, page ),
-				responseParser : x => new EbayGetSallerListCustomResponseParser().Parse( x ),
+				responseParser : x => new EbayGetSellerListCustomResponseParser().Parse( x ),
 				cts : CancellationToken.None,
 				mark : mark
 			).ConfigureAwait( false );
@@ -349,7 +352,7 @@ namespace EbayAccess.Services
 		public async Task< IEnumerable< GetSellerListCustomResponse > > GetSellerListCustomResponsesWithMaxThreadsRestrictionAsync( CancellationToken ct, DateTime timeFrom, DateTime timeTo, GetSellerListTimeRangeEnum getSellerListTimeRangeEnum, string mark )
 		{
 			if( ct.IsCancellationRequested )
-				return null;
+				throw new TaskCanceledException( $"Request was cancelled or timed out, Mark: {mark}" );
 
 			var recordsPerPage = this._itemsPerPage;
 			const int pageNumber = 1;
@@ -378,7 +381,7 @@ namespace EbayAccess.Services
 		public async Task< IEnumerable< GetSellerListCustomProductResponse > > GetSellerListCustomProductResponsesWithMaxThreadsRestrictionAsync( CancellationToken ct, DateTime timeFrom, DateTime timeTo, GetSellerListTimeRangeEnum getSellerListTimeRangeEnum, string mark )
 		{
 			if( ct.IsCancellationRequested )
-				return null;
+				throw new TaskCanceledException( $"Request was cancelled or timed out, Mark: {mark}" );
 
 			var recordsPerPage = this._itemsPerPage;
 			const int pageNumber = 1;
@@ -409,8 +412,8 @@ namespace EbayAccess.Services
 			return await this.GetEbaySingleRequestAsync< GetSellerListCustomResponse >(
 				headers : CreateGetSellerListRequestHeadersWithApiCallName(),
 				body : this.CreateGetSellerListCustomRequestBody( timeFrom, timeTo, getSellerListTimeRangeEnum, recordsPerPage, pageNumber ),
-				responseParser : x => new EbayGetSallerListCustomResponseParser().Parse( x ),
-				cts : ct,
+				responseParser : x => new EbayGetSellerListCustomResponseParser().Parse( x ),
+				token : ct,
 				mark : mark
 			).ConfigureAwait( false );
 		}
@@ -421,7 +424,7 @@ namespace EbayAccess.Services
 				headers : CreateGetSellerListRequestHeadersWithApiCallName(),
 				body : this.CreateGetSellerListCustomProductRequestBody( timeFrom, timeTo, getSellerListTimeRangeEnum, recordsPerPage, pageNumber ),
 				responseParser : x => new EbayGetSellerListCustomProductResponseParser().Parse( x ),
-				cts : ct,
+				token : ct,
 				mark : mark
 			).ConfigureAwait( false );
 		}
@@ -450,7 +453,7 @@ namespace EbayAccess.Services
 				headers : CreateGetItemRequestHeadersWithApiCallName(),
 				body : this.CreateGetItemByIdRequestBody( id ),
 				responseParser : x => new EbayGetItemResponseParser().Parse( x ),
-				cts : CancellationToken.None,
+				token : CancellationToken.None,
 				mark : mark
 			).ConfigureAwait( false );
 
@@ -500,7 +503,7 @@ namespace EbayAccess.Services
 				headers : CreateReviseInventoryStatusHeadersWithApiCallName(),
 				body : this.CreateReviseInventoryStatusRequestBody( inventoryStatusReq, inventoryStatusReq2, inventoryStatusReq3, inventoryStatusReq4 ),
 				responseParser : x => new EbayReviseInventoryStatusResponseParser().Parse( x ),
-				cts : CancellationToken.None,
+				token : CancellationToken.None,
 				mark : mark,
 				useCert: true
 			).ConfigureAwait( false );
@@ -593,7 +596,7 @@ namespace EbayAccess.Services
 				headers : CreateReviseFixedPriceItemHeadersWithApiCallName(),
 				body : this.CreateReviseFixedPriceItemRequestBody( fixedPriceItem ),
 				responseParser : x => new EbayReviseFixedPriceItemResponseParser().Parse( x ),
-				cts : CancellationToken.None,
+				token : CancellationToken.None,
 				mark : mark,
 				useCert: true
 			).ConfigureAwait( false );
@@ -641,7 +644,7 @@ namespace EbayAccess.Services
 
 			ActionPolicies.Get.Do( () =>
 			{
-				var webRequest = this.CreateEbayStandartPostRequestWithCert( this._endPoint, headers, body, mark );
+				var webRequest = this.CreateEbayStandardPostRequestWithCert( this._endPoint, headers, body, mark );
 
 				using( var memStream = this._webRequestServices.GetResponseStream( webRequest, mark ) )
 				{
@@ -672,7 +675,7 @@ namespace EbayAccess.Services
 
 			var body = this.CreateFetchTokenRequestBody( sessionId );
 			var headers = CreateFetchTokenRequestHeadersWithApiCallName();
-			var webRequest = this.CreateEbayStandartPostRequestWithCert( this._endPoint, headers, body, mark );
+			var webRequest = this.CreateEbayStandardPostRequestWithCert( this._endPoint, headers, body, mark );
 
 			using( var memStream = this._webRequestServices.GetResponseStream( webRequest, mark ) )
 			{
@@ -696,7 +699,7 @@ namespace EbayAccess.Services
 
 			await ActionPolicies.GetAsync.Do( async () =>
 			{
-				var webRequest = await this.CreateEbayStandartPostRequestToBulkExchangeServerAsync( this._endPointBulkExhange, headers, body ).ConfigureAwait( false );
+				var webRequest = await this.CreateEbayStandardPostRequestToBulkExchangeServerAsync( this._endPointBulkExhange, headers, body ).ConfigureAwait( false );
 
 				using( var memStream = await this._webRequestServices.GetResponseStreamAsync( webRequest, mark, CancellationToken.None ).ConfigureAwait( false ) )
 				{
@@ -727,7 +730,7 @@ namespace EbayAccess.Services
 
 			await ActionPolicies.GetAsync.Do( async () =>
 			{
-				var webRequest = await this.CreateEbayStandartPostRequestToBulkExchangeServerAsync( this._endPointBulkExhange, headers, body ).ConfigureAwait( false );
+				var webRequest = await this.CreateEbayStandardPostRequestToBulkExchangeServerAsync( this._endPointBulkExhange, headers, body ).ConfigureAwait( false );
 
 				using( var memStream = await this._webRequestServices.GetResponseStreamAsync( webRequest, mark, CancellationToken.None ).ConfigureAwait( false ) )
 				{
@@ -780,9 +783,9 @@ namespace EbayAccess.Services
 		#endregion
 
 		#region Generic requests
-		public async Task< TResponse > GetEbaySingleRequestAsync< TResponse >( Dictionary< string, string > headers, string body, Func< Stream, TResponse > responseParser, CancellationToken cts, string mark = "", bool useCert = false ) where TResponse : EbayBaseResponse, new()
+		public async Task< TResponse > GetEbaySingleRequestAsync< TResponse >( Dictionary< string, string > headers, string body, Func< Stream, TResponse > responseParser, CancellationToken token, string mark = "", bool useCert = false, int pageNumber = -1 ) where TResponse : EbayBaseResponse, new()
 		{
-			if( cts.IsCancellationRequested )
+			if( token.IsCancellationRequested )
 				throw new WebException( "Task was canceled" );
 
 			var response = new TResponse();
@@ -791,12 +794,21 @@ namespace EbayAccess.Services
 
 			await ActionPolicies.GetAsyncShort.Do( async () =>
 			{
-				var webRequest = await ( useCert ? this.CreateEbayStandartPostRequestWithCertAsync( this._endPoint, headers, body, mark, cts ) : this.CreateEbayStandartPostRequestAsync( this._endPoint, headers, body, mark, cts ) ).ConfigureAwait( false );
+				var webRequest = await ( useCert ? this.CreateEbayStandardPostRequestWithCertAsync( this._endPoint, headers, body, mark, token ) : this.CreateEbayStandardPostRequestAsync( this._endPoint, headers, body, mark, token ) ).ConfigureAwait( false );
 
 				TResponse parsedResponse;
-				using( var memStream = await this._webRequestServices.GetResponseStreamAsync( webRequest, mark, cts ).ConfigureAwait( false ) )
+				var timeoutToken = CreateTimeoutLinkedToken( token, this.RequestTimeoutMs );
+				using( var memStream = await this._webRequestServices.GetResponseStreamAsync( webRequest, mark, timeoutToken ).ConfigureAwait( false ) )
 				{
-					parsedResponse = responseParser( memStream );
+					if ( memStream != null ) 
+					{ 
+						parsedResponse = responseParser( memStream );
+					} 
+					else
+					{
+						var pageNumberLog = pageNumber != -1 ? $" for page{pageNumber}" : "";
+						throw new EbayCommonException( $"Blank memory stream is returned{pageNumberLog}; Mark:{mark}" );
+					}
 				}
 
 				if( parsedResponse != null )
@@ -828,6 +840,13 @@ namespace EbayAccess.Services
 			return response;
 		}
 
+		private static CancellationToken CreateTimeoutLinkedToken( CancellationToken token, int timeoutMs = MaxRequestTimeoutMs )
+		{
+			var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource( token );
+			linkedTokenSource.CancelAfter( timeoutMs );
+			return linkedTokenSource.Token;
+		}
+
 		private async Task< TResponse > GetEbayMultiPageRequestAsync< TResponse >( Dictionary< string, string > headers, Func< int, string > getRequestBodyByPageNumber, Func< Stream, TResponse > responseParser, CancellationToken cts, string mark = "", bool useCert = false ) where TResponse : EbayBaseResponse, IPaginationResponse< TResponse >, new()
 		{
 			var response = new TResponse();
@@ -842,9 +861,10 @@ namespace EbayAccess.Services
 					headers : headers,
 					body : getRequestBodyByPageNumber( pageNumber ),
 					responseParser : responseParser,
-					cts : cts,
+					token : cts,
 					mark : mark,
-					useCert : useCert
+					useCert : useCert,
+					pageNumber: pageNumber
 				).ConfigureAwait( false );
 
 				if( page.Errors != null )

--- a/src/EbayAccess/Services/IEbayServiceLowLevel.cs
+++ b/src/EbayAccess/Services/IEbayServiceLowLevel.cs
@@ -40,7 +40,7 @@ namespace EbayAccess.Services
 
 		Task< GetSellerListCustomResponse > GetSellerListCustomAsync( DateTime timeFrom, DateTime timeTo, GetSellerListTimeRangeEnum getSellerListTimeRangeEnum, string mark );
 
-		Task< WebRequest > CreateEbayStandartPostRequestToBulkExchangeServerAsync( string url, Dictionary< string, string > headers, string body, string mark );
+		Task< WebRequest > CreateEbayStandardPostRequestToBulkExchangeServerAsync( string url, Dictionary< string, string > headers, string body, string mark );
 
 		Task< CreateJobResponse > CreateUploadJobAsync( Guid guid, string mark );
 
@@ -48,7 +48,7 @@ namespace EbayAccess.Services
 
 		Task< GetOrdersResponse > GetOrdersAsync( CancellationToken cts, string mark = "", params string[] ordersIds );
 
-		Task< GetSellingManagerSoldListingsResponse > GetSellngManagerOrderByRecordNumberAsync( string salerecordNumber, string mark, CancellationToken cts );
+		Task< GetSellingManagerSoldListingsResponse > GetSellingManagerOrderByRecordNumberAsync( string saleRecordNumber, string mark, CancellationToken cts );
 
 		Task< GetSellingManagerSoldListingsResponse > GetSellingManagerSoldListingsByPeriodAsync( DateTime timeFrom, DateTime timeTo, CancellationToken ct, int pageLimit, string mark );
 

--- a/src/EbayAccess/Services/Parsers/EbayBulkAbortJobParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayBulkAbortJobParser.cs
@@ -10,7 +10,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayBulkAbortJobParser : EbayXmlParser< AbortJobResponse >
 	{
-		public override AbortJobResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override AbortJobResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -26,7 +26,7 @@ namespace EbayAccess.Services.Parsers
 
 				var res = new AbortJobResponse();
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = streamStartPos;
 
 				return res;

--- a/src/EbayAccess/Services/Parsers/EbayBulkCreateJobParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayBulkCreateJobParser.cs
@@ -10,7 +10,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayBulkCreateJobParser : EbayXmlParser< CreateJobResponse >
 	{
-		public override CreateJobResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override CreateJobResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -27,7 +27,7 @@ namespace EbayAccess.Services.Parsers
 
 				var res = new CreateJobResponse { JobId = GetElementValue( root, ns, "jobId" ) };
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = streamStartPos;
 
 				return res;

--- a/src/EbayAccess/Services/Parsers/EbayFetchTokenResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayFetchTokenResponseParser.cs
@@ -9,7 +9,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayFetchTokenResponseParser : EbayXmlParser< FetchTokenResponse >
 	{
-		public override FetchTokenResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override FetchTokenResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -25,7 +25,7 @@ namespace EbayAccess.Services.Parsers
 
 				var res = new FetchTokenResponse { EbayAuthToken = GetElementValue( root, ns, "eBayAuthToken" ), HardExpirationTime = GetElementValue( root, ns, "HardExpirationTime" ).ToDateTime() };
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = streamStartPos;
 
 				return res;

--- a/src/EbayAccess/Services/Parsers/EbayGetItemResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetItemResponseParser.cs
@@ -12,7 +12,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayGetItemResponseParser : EbayXmlParser< GetItemResponse >
 	{
-		public override GetItemResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetItemResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -136,7 +136,7 @@ namespace EbayAccess.Services.Parsers
 					res.Variations.AddRange( variationsObj );
 				}
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = streamStartPos;
 
 				return new GetItemResponse { Item = res };

--- a/src/EbayAccess/Services/Parsers/EbayGetOrdersResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetOrdersResponseParser.cs
@@ -10,7 +10,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayGetOrdersResponseParser : EbayXmlParser< GetOrdersResponse >
 	{
-		public override GetOrdersResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetOrdersResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -261,7 +261,7 @@ namespace EbayAccess.Services.Parsers
 					}
 					#endregion
 
-					if( keepStremPosition )
+					if( keepStreamPosition )
 						stream.Position = streamStartPos;
 
 					return resultOrder;
@@ -272,6 +272,8 @@ namespace EbayAccess.Services.Parsers
 			}
 			catch( Exception ex )
 			{
+				if( stream == null ) 
+					throw new EbayCommonException( "Returned stream is null", ex );
 				var buffer = new byte[ stream.Length ];
 				stream.Read( buffer, 0, ( int )stream.Length );
 				var utf8Encoding = new UTF8Encoding();

--- a/src/EbayAccess/Services/Parsers/EbayGetSallerListResponseCustomParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetSallerListResponseCustomParser.cs
@@ -9,9 +9,9 @@ using EbayAccess.Models.GetSellerListCustomResponse;
 
 namespace EbayAccess.Services.Parsers
 {
-	public class EbayGetSallerListCustomResponseParser : EbayXmlParser< GetSellerListCustomResponse >
+	public class EbayGetSellerListCustomResponseParser : EbayXmlParser< GetSellerListCustomResponse >
 	{
-		public override GetSellerListCustomResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetSellerListCustomResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -96,7 +96,7 @@ namespace EbayAccess.Services.Parsers
 						res.Variations.AddRange( variationsObj );
 					}
 
-					if( keepStremPosition )
+					if( keepStreamPosition )
 						stream.Position = streamStartPos;
 
 					return res;

--- a/src/EbayAccess/Services/Parsers/EbayGetSallerListResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetSallerListResponseParser.cs
@@ -10,7 +10,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayGetSallerListResponseParser : EbayXmlParser< GetSellerListResponse >
 	{
-		public override GetSellerListResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetSellerListResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -125,7 +125,7 @@ namespace EbayAccess.Services.Parsers
 						res.PrimaryCategory.CategoryName = GetElementValue( x, ns, "PrimaryCategory", "CategoryName" );
 					}
 
-					if( keepStremPosition )
+					if( keepStreamPosition )
 						stream.Position = streamStartPos;
 
 					return res;

--- a/src/EbayAccess/Services/Parsers/EbayGetSellingManagerSoldListingsResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetSellingManagerSoldListingsResponseParser.cs
@@ -10,7 +10,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayGetSellingManagerSoldListingsResponseParser : EbayXmlParser< GetSellingManagerSoldListingsResponse >
 	{
-		public override GetSellingManagerSoldListingsResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetSellingManagerSoldListingsResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -42,7 +42,7 @@ namespace EbayAccess.Services.Parsers
 					resultOrder.SaleRecordID = GetElementValue( x, ns, "SaleRecordID" );
 					resultOrder.CreationTime = GetElementValue( x, ns, "CreationTime" ).ToDateTime();
 
-					if( keepStremPosition )
+					if( keepStreamPosition )
 						stream.Position = streamStartPos;
 
 					return resultOrder;

--- a/src/EbayAccess/Services/Parsers/EbayGetSessionIdResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetSessionIdResponseParser.cs
@@ -8,7 +8,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayGetSessionIdResponseParser : EbayXmlParser< GetSessionIdResponse >
 	{
-		public override GetSessionIdResponse Parse( Stream stream, bool keepStremPosition = true )
+		public override GetSessionIdResponse Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -24,7 +24,7 @@ namespace EbayAccess.Services.Parsers
 
 				var res = new GetSessionIdResponse { SessionId = GetElementValue( root, ns, "SessionID" ), Build = GetElementValue( root, ns, "Build" ) };
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = streamStartPos;
 
 				return res;

--- a/src/EbayAccess/Services/Parsers/EbayPaginationResultResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayPaginationResultResponseParser.cs
@@ -8,7 +8,7 @@ namespace EbayAccess.Services.Parsers
 {
 	public class EbayPaginationResultResponseParser : EbayXmlParser< PaginationResult >
 	{
-		public override PaginationResult Parse( Stream stream, bool keepStremPosition = true )
+		public override PaginationResult Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			try
 			{
@@ -31,7 +31,7 @@ namespace EbayAccess.Services.Parsers
 						res.TotalNumberOfEntries = int.Parse( temp );
 				}
 
-				if( keepStremPosition )
+				if( keepStreamPosition )
 					stream.Position = 0;
 
 				return res;

--- a/src/EbayAccess/Services/Parsers/EbayXmlParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayXmlParser.cs
@@ -84,7 +84,7 @@ namespace EbayAccess.Services.Parsers
 				return Parse( stream );
 		}
 
-		public virtual TParseResult Parse( Stream stream, bool keepStremPosition = true )
+		public virtual TParseResult Parse( Stream stream, bool keepStreamPosition = true )
 		{
 			return default( TParseResult );
 		}

--- a/src/EbayAccessTests.Integration/EbayServiceTest.cs
+++ b/src/EbayAccessTests.Integration/EbayServiceTest.cs
@@ -40,7 +40,7 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersIdsAsync = service.GetOrdersIdsAsync( token: CancellationToken.None, ExistingOrdersIds.OrdersIds.ToArray() );
+			var ordersIdsAsync = service.GetOrdersIdsAsync( CancellationToken.None, ExistingOrdersIds.OrdersIds.ToArray() );
 			ordersIdsAsync.Wait();
 
 			//------------ Assert
@@ -54,7 +54,7 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersIdsAsync = service.GetOrdersIdsAsync( token:CancellationToken.None, NotExistingBecauseOfCombinedOrdersIds.OrdersIds.ToArray() );
+			var ordersIdsAsync = service.GetOrdersIdsAsync( CancellationToken.None, NotExistingBecauseOfCombinedOrdersIds.OrdersIds.ToArray() );
 			ordersIdsAsync.Wait();
 
 			//------------ Assert

--- a/src/EbayAccessTests.Integration/EbayServiceTest.cs
+++ b/src/EbayAccessTests.Integration/EbayServiceTest.cs
@@ -26,36 +26,11 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersIdsAsync = service.GetSaleRecordsNumbersAsync( ExistingOrdersIds.SaleNumers.ToArray() );
+			var ordersIdsAsync = service.GetSaleRecordsNumbersAsync( ExistingOrdersIds.SaleNumers.ToArray(), CancellationToken.None );
 			ordersIdsAsync.Wait();
 
 			//------------ Assert
 			ordersIdsAsync.Result.Should().BeEquivalentTo( ExistingOrdersIds.SaleNumers.ToArray() );
-		}
-
-		[ Test ]
-		public void GetSaleRecordsNumbers_ResponseTooksTooLongTime_Exception()
-		{
-			//------------ Arrange
-			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
-			service.DelayForMethod[ "GetSaleRecordsNumbersAsync" ] = 25500;
-
-			var saleNumbers = new List< string >();
-			var existingSaleNumbersArray = ExistingOrdersIds.SaleNumers.ToArray();
-			for( var i = 0; i < 1000; i++ )
-			{
-				saleNumbers.Add( existingSaleNumbersArray[ i % existingSaleNumbersArray.Length ] );
-			}
-
-			//------------ Act
-			Action act = () =>
-			{
-				var ordersIdsAsync = service.GetSaleRecordsNumbersAsync( saleNumbers.ToArray() );
-				ordersIdsAsync.Wait();
-			};
-
-			//------------ Assert
-			act.ShouldThrow< Exception >();
 		}
 
 		[ Test ]
@@ -65,7 +40,7 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersIdsAsync = service.GetOrdersIdsAsync( ExistingOrdersIds.OrdersIds.ToArray() );
+			var ordersIdsAsync = service.GetOrdersIdsAsync( token: CancellationToken.None, ExistingOrdersIds.OrdersIds.ToArray() );
 			ordersIdsAsync.Wait();
 
 			//------------ Assert
@@ -79,7 +54,7 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersIdsAsync = service.GetOrdersIdsAsync( NotExistingBecauseOfCombinedOrdersIds.OrdersIds.ToArray() );
+			var ordersIdsAsync = service.GetOrdersIdsAsync( token:CancellationToken.None, NotExistingBecauseOfCombinedOrdersIds.OrdersIds.ToArray() );
 			ordersIdsAsync.Wait();
 
 			//------------ Assert
@@ -93,7 +68,7 @@ namespace EbayAccessTests.Integration
 			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox() );
 
 			//------------ Act
-			var ordersTask = service.GetOrdersAsync( DateTime.Now.AddMonths( 0 ).AddDays( -29 ), DateTime.Now.AddMonths( 0 ) );
+			var ordersTask = service.GetOrdersAsync( DateTime.Now.AddMonths( 0 ).AddDays( -29 ), DateTime.Now.AddMonths( 0 ), CancellationToken.None );
 			ordersTask.Wait();
 
 			//------------ Assert

--- a/src/EbayAccessTests.Integration/EbayServiceTest.cs
+++ b/src/EbayAccessTests.Integration/EbayServiceTest.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using EbayAccess;
 using EbayAccess.Misc;
 using EbayAccess.Models;
 using EbayAccess.Models.GetSellerListCustomResponse;
 using EbayAccess.Models.ReviseFixedPriceItemRequest;
 using EbayAccess.Models.ReviseInventoryStatusRequest;
+using EbayAccess.Services;
 using EbayAccessTests.Integration.TestEnvironment;
 using FluentAssertions;
 using NUnit.Framework;
@@ -340,5 +342,21 @@ namespace EbayAccessTests.Integration
 			Debug.WriteLine( "products2 {0}, t:{1}", products2List.Count(), sw2.Elapsed.ToString() );
 		}
 		#endregion
+
+		[ Test ]
+		public void GetSaleRecordsNumbers_WhenLowTimeOutSet_ThenTimesOut()
+		{
+			const int reallyShortTimeout = 100;
+			var service = new EbayService( this._credentials.GetEbayUserCredentials(), this._credentials.GetEbayConfigSandbox(), 
+				new WebRequestServices(), reallyShortTimeout );
+
+			Action act = () =>
+			{
+				var ordersIdsAsync = service.GetSaleRecordsNumbersAsync( new [] { "123 " }.ToArray(), new CancellationToken() );
+				ordersIdsAsync.Wait();
+			};
+
+			act.ShouldThrow< EbayCommonException >();
+		}
 	}
 }

--- a/src/EbayAccessTests.Integration/Program.cs
+++ b/src/EbayAccessTests.Integration/Program.cs
@@ -24,7 +24,7 @@ namespace EbayAccessTests.Integration
 			var ebayService = ebayFactory.CreateService( this._credentials.GetEbayUserCredentials() );
 
 			//------------ Act
-			var ordersTask = ebayService.GetOrdersAsync( ExistingOrdersModifiedInRange.DateFrom, ExistingOrdersModifiedInRange.DateTo );
+			var ordersTask = ebayService.GetOrdersAsync( ExistingOrdersModifiedInRange.DateFrom, ExistingOrdersModifiedInRange.DateTo, CancellationToken.None );
 			ordersTask.Wait();
 			var orders = ordersTask.Result;
 

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="EbayServiceTest.cs" />
     <Compile Include="Misc\Extensions.cs" />
     <Compile Include="Misc\LoggerTests.cs" />
+    <Compile Include="Misc\TimeoutTests.cs" />
     <Compile Include="Models\CredentialsAndConfig\EbayConfigTest.cs" />
     <Compile Include="Models\GetSellerListResponse\ItemExtendedTest.cs" />
     <Compile Include="Models\GetSellerListResponse\ProductTests.cs" />

--- a/src/EbayAccessTests/EbayServiceTest.cs
+++ b/src/EbayAccessTests/EbayServiceTest.cs
@@ -26,7 +26,7 @@ namespace EbayAccessTests
 	public class EbayServiceTest : TestBase
 	{
 		[ Test ]
-		public void GetSellerListAsync_EbayServiceExistingItemsDevidedIntoMultiplePages_HookUpItemsFromAllPages()
+		public void GetSellerListAsync_EbayServiceExistingItemsDividedIntoMultiplePages_HookUpItemsFromAllPages()
 		{
 			//A
 			var stubCallCounter = 0;
@@ -38,7 +38,7 @@ namespace EbayAccessTests
 			};
 
 			var stubWebRequestService = new Mock< IWebRequestServices >();
-			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), CancellationToken.None ) ).Returns( () =>
+			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), It.IsAny< CancellationToken >() ) ).Returns( () =>
 			{
 				var ms = new MemoryStream();
 				var buf = new UTF8Encoding().GetBytes( serverResponsePages[ stubCallCounter ] );
@@ -65,7 +65,7 @@ namespace EbayAccessTests
 
 			var stubWebRequestService = Substitute.For< IWebRequestServices >();
 
-			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), CancellationToken.None ).Returns( x =>
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), Arg.Any< CancellationToken >() ).Returns( x =>
 			{
 				var ms = new MemoryStream();
 				var utf8Encoding = new UTF8Encoding();
@@ -94,17 +94,17 @@ namespace EbayAccessTests
 		{
 			//A
 			var stubWebRequestService = Substitute.For< IWebRequestServices >();
-			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), CancellationToken.None ).Returns( x => Task.FromResult( GetSellingManagerSoldListingsResponse.ResponseWithInternalError.ToStream() ) );
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), Arg.Any< CancellationToken >() ).Returns( x => Task.FromResult( GetSellingManagerSoldListingsResponse.ResponseWithInternalError.ToStream() ) );
 			var ebayServiceLowLevel = new EbayServiceLowLevel( this._testEmptyCredentials.GetEbayUserCredentials(), this._testEmptyCredentials.GetEbayDevCredentials(), stubWebRequestService );
 
 			//A
-			var sellngManagerOrderByRecordNumberAsync = ebayServiceLowLevel.GetSellngManagerOrderByRecordNumberAsync( "123", new Guid().ToString(), CancellationToken.None );
-			sellngManagerOrderByRecordNumberAsync.Wait();
+			var sellingManagerOrderByRecordNumberAsync = ebayServiceLowLevel.GetSellingManagerOrderByRecordNumberAsync( "123", new Guid().ToString(), CancellationToken.None );
+			sellingManagerOrderByRecordNumberAsync.Wait();
 
 			//A
 			stubWebRequestService.ReceivedWithAnyArgs( 4 ).GetResponseStreamAsync( null, new Guid().ToString(), CancellationToken.None );
-			sellngManagerOrderByRecordNumberAsync.Result.Errors.Count().Should().Be( 1 );
-			sellngManagerOrderByRecordNumberAsync.Result.Errors.Count( x => x.ErrorCode == "10007" ).Should().Be( 1 );
+			sellingManagerOrderByRecordNumberAsync.Result.Errors.Count().Should().Be( 1 );
+			sellingManagerOrderByRecordNumberAsync.Result.Errors.Count( x => x.ErrorCode == "10007" ).Should().Be( 1 );
 		}
 
 		[ Test ]
@@ -113,16 +113,16 @@ namespace EbayAccessTests
 			//A
 			var stubWebRequestService = Substitute.For< IWebRequestServices >();
 			var callCounter = 0;
-			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), CancellationToken.None ).Returns( x => Task.FromResult( callCounter++ == 0 ? GetSellingManagerSoldListingsResponse.ResponseWithInternalError.ToStream() : GetSellingManagerSoldListingsResponse.ResponseWithSoldRecord.ToStream() ) );
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), Arg.Any< CancellationToken >() ).Returns( x => Task.FromResult( callCounter++ == 0 ? GetSellingManagerSoldListingsResponse.ResponseWithInternalError.ToStream() : GetSellingManagerSoldListingsResponse.ResponseWithSoldRecord.ToStream() ) );
 			var ebayServiceLowLevel = new EbayServiceLowLevel( this._testEmptyCredentials.GetEbayUserCredentials(), this._testEmptyCredentials.GetEbayDevCredentials(), stubWebRequestService );
 
 			//A
-			var sellngManagerOrderByRecordNumberAsync = ebayServiceLowLevel.GetSellngManagerOrderByRecordNumberAsync( "123", new Guid().ToString(), CancellationToken.None );
-			sellngManagerOrderByRecordNumberAsync.Wait();
+			var sellingManagerOrderByRecordNumberAsync = ebayServiceLowLevel.GetSellingManagerOrderByRecordNumberAsync( "123", new Guid().ToString(), CancellationToken.None );
+			sellingManagerOrderByRecordNumberAsync.Wait();
 
 			//A
 			stubWebRequestService.ReceivedWithAnyArgs( 2 ).GetResponseStreamAsync( null, new Guid().ToString(), CancellationToken.None );
-			sellngManagerOrderByRecordNumberAsync.Result.Errors.Should().BeNull();
+			sellingManagerOrderByRecordNumberAsync.Result.Errors.Should().BeNull();
 		}
 
 		[ Test ]
@@ -133,7 +133,7 @@ namespace EbayAccessTests
 
 			var stubWebRequestService = Substitute.For< IWebRequestServices >();
 
-			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), CancellationToken.None ).Returns( x =>
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), Arg.Any< CancellationToken >() ).Returns( x =>
 			{
 				var ms = new MemoryStream();
 				var utf8Encoding = new UTF8Encoding();
@@ -157,7 +157,7 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public void GetOrdersAsync_EbayServiceExistingOrdersDevidedIntoMultiplePages_HookUpItemsFromAllPages()
+		public void GetOrdersAsync_EbayServiceExistingOrdersDividedIntoMultiplePages_HookUpItemsFromAllPages()
 		{
 			//A
 			var stubCallCounter = 0;
@@ -169,7 +169,7 @@ namespace EbayAccessTests
 
 			var stubWebRequestService = new Mock< IWebRequestServices >();
 
-			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), CancellationToken.None ) ).Returns( () =>
+			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), It.IsAny< CancellationToken >() ) ).Returns( () =>
 			{
 				var ms = new MemoryStream();
 				var encoding = new UTF8Encoding();
@@ -192,7 +192,8 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public async Task InvokeReviseInventoriesStatusAsync_EbayServiceReturnsErrorOnReviseInventoriesStatusReqest_HaveErrorMessageFromEbayServerInResult()
+		[ Explicit ]
+		public async Task InvokeReviseInventoriesStatusAsync_EbayServiceReturnsErrorOnReviseInventoriesStatusRequest_HaveErrorMessageFromEbayServerInResult()
 		{
 			//A
 			const int itemsQty1 = 100;
@@ -201,7 +202,7 @@ namespace EbayAccessTests
 			const string serverResponse = "<ReviseInventoryStatusResponse xmlns=\"urn:ebay:apis:eBLBaseComponents\"><Timestamp>2014-02-17T18:49:00.346Z</Timestamp><Ack>Failure</Ack><Errors><ShortMessage>FixedPrice item ended.</ShortMessage><LongMessage>You are not allowed to revise an ended item \"110136942332\".</LongMessage><ErrorCode>21916750</ErrorCode><SeverityCode>Error</SeverityCode><ErrorParameters ParamID=\"0\"><Value>110136942332</Value></ErrorParameters><ErrorClassification>RequestError</ErrorClassification></Errors><Version>859</Version><Build>E859_UNI_API5_16675060_R1</Build></ReviseInventoryStatusResponse>";
 
 			var stubWebRequestService = new Mock< IWebRequestServices >();
-			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), CancellationToken.None ) ).Returns(
+			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), It.IsAny< CancellationToken >() ) ).Returns(
 				() =>
 				{
 					var ms = new MemoryStream();
@@ -225,6 +226,7 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void InvokeReviseInventoriesStatusAsync_EbayServiceReturnsImageSizeError_NoExceptionOccurs()
 		{
 			//A
@@ -233,7 +235,7 @@ namespace EbayAccessTests
 			const long item2Id = 110137091582;
 
 			var stubWebRequestService = new Mock< IWebRequestServices >();
-			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), CancellationToken.None ) ).Returns( () => Task.FromResult( ReviseFixedPriceItemResponse.ServerResponseContainsPictureError.ToStream() ) );
+			stubWebRequestService.Setup( x => x.GetResponseStreamAsync( It.IsAny< WebRequest >(), It.IsAny< string >(), It.IsAny< CancellationToken >() ) ).Returns( () => Task.FromResult( ReviseFixedPriceItemResponse.ServerResponseContainsPictureError.ToStream() ) );
 
 			var ebayService = new EbayService( this._testEmptyCredentials.GetEbayUserCredentials(), this._testEmptyCredentials.GetEbayDevCredentials(), stubWebRequestService.Object );
 
@@ -249,7 +251,8 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public void UpdateFixePriceProductsAsync_UpdateBy0EbayServiceReturnsLvsBlockError_ErrorSkipedAndNoExceptionOccurs()
+		[ Explicit ]
+		public void UpdateFixedPriceProductsAsync_UpdateBy0EbayServiceReturnsLvsBlockError_ErrorSkippedAndNoExceptionOccurs()
 		{
 			//A
 			const int itemsQty1 = 0;
@@ -276,7 +279,8 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public void UpdateFixePriceProductsAsync_UpdateByGreaterThan0EbayServiceReturnsLvsBlockError_ErrorSkipedAndNoExceptionOccurs()
+		[ Explicit ]
+		public void UpdateFixedPriceProductsAsync_UpdateByGreaterThan0EbayServiceReturnsLvsBlockError_ErrorSkippedAndNoExceptionOccurs()
 		{
 			//A
 			const int itemsQty1 = 1;
@@ -312,7 +316,7 @@ namespace EbayAccessTests
 			var getResponseStreamAsyncCallCounter = 0;
 
 			var stubWebRequestService = Substitute.For< IWebRequestServices >();
-			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), CancellationToken.None ).Returns( Task.FromResult( respstring.ToStream() ) ).AndDoes( x => getResponseStreamAsyncCallCounter++ );
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< string >(), Arg.Any< CancellationToken >() ).Returns( Task.FromResult( respstring.ToStream() ) ).AndDoes( x => getResponseStreamAsyncCallCounter++ );
 
 			var ebayService = new EbayService( this._testEmptyCredentials.GetEbayUserCredentials(), this._testEmptyCredentials.GetEbayDevCredentials(), stubWebRequestService );
 
@@ -332,7 +336,8 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public void UpdateInventoryAsync_ExceptionOccuredAlways_ReviseInventoryStatusExceptionsDontBreakReviseFixdPriceProcessAndViseVersa()
+		[ Explicit ]
+		public void UpdateInventoryAsync_ExceptionOccuredAlways_ReviseInventoryStatusExceptionsDoesntBreakReviseFixedPriceProcessAndViseVersa()
 		{
 			//A
 			const int maxThreadsCount = 18;
@@ -364,13 +369,14 @@ namespace EbayAccessTests
 			action.ShouldThrow< EbayCommonException >();
 
 			stubWebRequestService.Received().CreateServicePostRequestAsync( Arg.Any< string >(), Arg.Any< string >(), Arg.Is< Dictionary< string, string > >( x =>
-				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseFixedPriceItem ), CancellationToken.None, Arg.Any< string >() );
+				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseFixedPriceItem ), Arg.Any< CancellationToken >(), Arg.Any< string >() );
 			stubWebRequestService.Received().CreateServicePostRequestAsync( Arg.Any< string >(), Arg.Any< string >(), Arg.Is< Dictionary< string, string > >( x =>
-				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseInventoryStatus ), CancellationToken.None, Arg.Any< string >() );
+				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseInventoryStatus ), Arg.Any< CancellationToken >(), Arg.Any< string >() );
 		}
 
 		[ Test ]
-		public void ReviseFixePriceItemsAsync_ExceptionOccured_ExceptionDontBreaksProcessingAndThereWasAttemptsToReviseAllItems()
+		[ Explicit ]
+		public void ReviseFixedPriceItemsAsync_ExceptionOccured_ExceptionDoesntBreakProcessingAndThereWasAttemptsToReviseAllItems()
 		{
 			//A
 			const int maxThreadsCount = 18;
@@ -399,11 +405,12 @@ namespace EbayAccessTests
 			action.ShouldThrow< Exception >();
 
 			stubWebRequestService.Received( requiredNumberOfCalls ).CreateServicePostRequestAsync( Arg.Any< string >(), Arg.Any< string >(), Arg.Is< Dictionary< string, string > >( x =>
-				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseFixedPriceItem ), CancellationToken.None, Arg.Any< string >() );
+				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseFixedPriceItem ), Arg.Any< CancellationToken >(), Arg.Any< string >() );
 		}
 
 		[ Test ]
-		public void ReviseInventoriesStatusAsync_ExceptionOccured_ExceptionDontBreaksProcessingAndThereWasAttemptsToReviseAllItems()
+		[ Explicit ]
+		public void ReviseInventoriesStatusAsync_ExceptionOccured_ExceptionDoesntBreakProcessingAndThereWasAttemptsToReviseAllItems()
 		{
 			//A
 			const int maxThreadsCount = 18;
@@ -430,10 +437,11 @@ namespace EbayAccessTests
 
 			var requiredNumberOfCalls = inventoryStatusRequests.Count / 4 + ( inventoryStatusRequests.Count % 4 > 0 ? 1 : 0 );
 			stubWebRequestService.Received( requiredNumberOfCalls ).CreateServicePostRequestAsync( Arg.Any< string >(), Arg.Any< string >(), Arg.Is< Dictionary< string, string > >( x =>
-				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseInventoryStatus ), CancellationToken.None, Arg.Any< string >() );
+				x[ EbayHeaders.XEbayApiCallName ] == EbayHeadersMethodnames.ReviseInventoryStatus ), Arg.Any< CancellationToken >(), Arg.Any< string >() );
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateInventoryAsync_UnsupportedListingTypeErrorOccured_ErrorSkippedAndNoExceptionOccurs()
 		{
 			//A
@@ -460,6 +468,7 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateInventoryAsync_UpdateItemsProducesReplaceableValueError_NoExceptionOccuredAndResponseContainsOnlyUpdatedItemId()
 		{
 			//A
@@ -486,7 +495,8 @@ namespace EbayAccessTests
 		}
 
 		[ Test ]
-		public void UpdateInventoryAsync_AdditionalLogInfoSetuped_AdditionalLogInfoCalledDuringUpdatingInventory8times()
+		[ Explicit ]
+		public void UpdateInventoryAsync_AdditionalLogInfoSetup_AdditionalLogInfoCalledDuringUpdatingInventory8times()
 		{
 			//A
 			const long item1Id = 110136942332;

--- a/src/EbayAccessTests/Misc/TimeoutTests.cs
+++ b/src/EbayAccessTests/Misc/TimeoutTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EbayAccess.Services;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EbayAccessTests.Misc
+{
+	[ TestFixture ]
+	public class TimeoutTests
+	{
+		[ Test ]
+		public void GivenLowTimeout_WhenCallGetResponseStreamAsync_ThenThrowsTaskCanceledException()
+		{
+			const int reallyShortTimeout = 1;
+			var webRequestServices = new WebRequestServices();
+			var token = new CancellationTokenSource( reallyShortTimeout );
+
+			Action act = () =>
+			{
+				var request = webRequestServices.CreateServiceGetRequest( "http://localhost", new Dictionary< string, string >() );
+				var orderTask = webRequestServices.GetResponseStreamAsync( request, "", token.Token );
+				orderTask.Wait();
+			};
+			
+			act.ShouldThrow< TaskCanceledException >();
+		}
+	}
+}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.4.4.0" ) ]
+[ assembly : AssemblyVersion( "1.4.5.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.3.1.0" ) ]
+[ assembly : AssemblyVersion( "1.4.2.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.4.2.0" ) ]
+[ assembly : AssemblyVersion( "1.4.3.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.4.3.0" ) ]
+[ assembly : AssemblyVersion( "1.4.4.0" ) ]


### PR DESCRIPTION
- For Orders Sync-related requests, moved timeouts from batch operations (get orders by date) to individual requests
- Added cancellation token to all Orders Syc methods
- When task is cancelled now throw TaskCanceledException instead of returning null stream, which is extremely misleading
- Corrected numerous typos