### PR TITLE
2020-12-22 GUARD-925 GetSellingManagerOrder-Database-Error

### DIFF
--- a/src/EbayAccess/Models/BaseResponse/EbayBaseResponse.cs
+++ b/src/EbayAccess/Models/BaseResponse/EbayBaseResponse.cs
@@ -7,7 +7,7 @@ namespace EbayAccess.Models.BaseResponse
 {
 	public class EbayBaseResponse
 	{
-		private static readonly List< ResponseError > _internalErrors = new List< ResponseError > { new ResponseError { ErrorCode = "10007" }, new ResponseError { ErrorCode = "16100" } };
+		private static readonly List< ResponseError > _internalErrors = new List< ResponseError > { new ResponseError { ErrorCode = "10007" }, new ResponseError { ErrorCode = "16100" }, new ResponseError { ErrorCode = "248" } };
 		private static readonly List< ResponseError > _invalidTokenErrors = new List< ResponseError > { new ResponseError { ErrorCode = "931" }, new ResponseError { ErrorCode = "932" } };
 
 		public DateTime Timestamp { get; set; }

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -128,6 +128,9 @@
     <Content Include="Files\GetOrdersResponse\EbayServiceGetOrdersResponseWithOutItems.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Files\GetOrdersResponse\EbayServiceGetSaleRecordsNumbersResponseWithDatabaseError.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Files\GetSellerListCustomProductResponse\EbayServiceGetSellerListCustomProductResponse.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/EbayAccessTests/Files/GetOrdersResponse/EbayServiceGetSaleRecordsNumbersResponseWithDatabaseError.xml
+++ b/src/EbayAccessTests/Files/GetOrdersResponse/EbayServiceGetSaleRecordsNumbersResponseWithDatabaseError.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<GetSellingManagerSoldListingsResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+	<Timestamp>2020-11-17T23:10:38.231Z</Timestamp>
+	<Ack>Failure</Ack>
+	<Errors>
+		<ShortMessage>Database Server Error.</ShortMessage>
+		<LongMessage>Database Server exception occurred.</LongMessage>
+		<ErrorCode>248</ErrorCode>
+		<SeverityCode>Error</SeverityCode>
+		<ErrorClassification>RequestError</ErrorClassification>
+	</Errors>
+	<Version>1163</Version>
+	<Build>E1163_CORE_APISELLING_19187371_R1</Build>
+</GetSellingManagerSoldListingsResponse>

--- a/src/EbayAccessTests/Services/EbayServiceLowLevelTest.cs
+++ b/src/EbayAccessTests/Services/EbayServiceLowLevelTest.cs
@@ -125,5 +125,25 @@ namespace EbayAccessTests.Services
 				Arg.Is< string >( x => new XmlDocument().TryParse( x ) ),
 				Arg.Any< Dictionary< string, string > >(), Arg.Any< CancellationToken >(), Arg.Any< Mark >() );
 		}
+
+		[ Test ]
+		public async Task GivenSaleRecordNumbers_WhenGetEbaySingleRequestAsyncIsCalledWithDatabaseError_ThenRetryAttemptsExpected()
+		{
+			var sellingManagerSaleRecordNumber = "879";
+			string ebayServerResponse;
+			using( var fs = new FileStream( @".\Files\GetOrdersResponse\EbayServiceGetSaleRecordsNumbersResponseWithDatabaseError.xml", FileMode.Open, FileAccess.Read ) )
+				ebayServerResponse = new StreamReader( fs ).ReadToEnd();
+			var getResponseStreamAsyncCallCounter = 0;
+
+			var stubWebRequestService = Substitute.For< IWebRequestServices >();
+			stubWebRequestService.GetResponseStreamAsync( Arg.Any< WebRequest >(), Arg.Any< Mark >(), Arg.Any< CancellationToken >() )
+				.Returns( x => Task.FromResult( ebayServerResponse.ToStream() ) ).AndDoes( x => getResponseStreamAsyncCallCounter++ );
+			var ebayService = new EbayServiceLowLevel( this._testEmptyCredentials.GetEbayUserCredentials(), this._testEmptyCredentials.GetEbayDevCredentials(), stubWebRequestService );
+
+			var ordersRecordsResponse = await ebayService.GetSellingManagerOrderByRecordNumberAsync( sellingManagerSaleRecordNumber, Mark.Blank(), CancellationToken.None );
+
+			ordersRecordsResponse.Errors.Count().Should().BeGreaterThan( 0 );
+			getResponseStreamAsyncCallCounter.Should().Be( 4 );
+		}
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.5.2.0" ) ]
+[ assembly : AssemblyVersion( "1.5.3.0" ) ]


### PR DESCRIPTION
**Summary**

Ebay server sometimes returns "database error" when SV tries to pull orders by selling manager sale record number (Selling Manager PRO APIs).
We can't just skip this error and continue because SV checks missing orders using the request above. So after the fix, access library will try to repeat request if such error happened.

Error example:
`<GetSellingManagerSoldListingsResponse xmlns=\"urn:ebay:apis:eBLBaseComponents\">
<Timestamp>2020-11-17T23:10:38.231Z</Timestamp>
<Ack>Failure</Ack>
<Errors>
	<ShortMessage>Database Server Error.</ShortMessage>
	<LongMessage>Database Server exception occurred.</LongMessage>
	<ErrorCode>248</ErrorCode>
        <SeverityCode>Error</SeverityCode>
	<ErrorClassification>RequestError</ErrorClassification>
</Errors>
<Version>1163</Version>
<Build>E1163_CORE_APISELLING_19187371_R1</Build>
</GetSellingManagerSoldListingsResponse>`

Temporary PR (just for convience): https://github.com/skuvault/ebayAccess/pull/18