### PR TITLE
2021-02-11 GUARD-1749 Change-Sales-Order-Number

### DIFF
--- a/src/EbayAccess/Services/EbayServiceLowLevel.cs
+++ b/src/EbayAccess/Services/EbayServiceLowLevel.cs
@@ -172,7 +172,7 @@ namespace EbayAccess.Services
 			return new Dictionary< string, string >
 			{
 				{ EbayHeaders.XEbayApiCallName, EbayHeadersMethodnames.GetOrders },
-				{  EbayHeaders.XEbayApiCompatibilityLevel, "1057"}
+				{ EbayHeaders.XEbayApiCompatibilityLevel, "1113" }
 			};
 		}
 

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.5.3.0" ) ]
+[ assembly : AssemblyVersion( "1.6.0.0" ) ]


### PR DESCRIPTION
**Summary**
Upgraded API compatibility level to version 1113 to support new order id format.

https://developer.ebay.com/devzone/xml/docs/Reference/eBay/GetOrders.html#Response.OrderArray.Order.ExtendedOrderID

> During the transition period, for developers/sellers using a Trading WSDL older than Version 1113, they can use the X-EBAY-API-COMPATIBILITY-LEVEL HTTP header in API calls to control whether the new or old OrderID format is returned in call response payloads. To get the new OrderID format, the value of the X-EBAY-API-COMPATIBILITY-LEVEL HTTP header must be set to 1113